### PR TITLE
feat: Broker exposto com symbol_info e symbol_info_tick

### DIFF
--- a/fxbot/adapters/broker.py
+++ b/fxbot/adapters/broker.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Any, List, Optional
 import pandas as pd
 from core.types import OrderRequest, PositionView
 
@@ -20,6 +20,11 @@ class Broker(ABC):
     def get_digits(self, symbol: str) -> int: ...
     @abstractmethod
     def place_order(self, req: OrderRequest): ...
+
+    @abstractmethod
+    def symbol_info(self, symbol: str) -> Any: ...
+    @abstractmethod
+    def symbol_info_tick(self, symbol: str) -> Any: ...
 
     @abstractmethod
     def positions(self, symbol: Optional[str]

--- a/fxbot/adapters/mt5.py
+++ b/fxbot/adapters/mt5.py
@@ -55,6 +55,14 @@ class MT5Broker(Broker):
         }
         return mt5.order_send(mreq)
 
+    def symbol_info(self, symbol: str):
+        """Retorna informações completas do símbolo."""
+        return mt5.symbol_info(symbol)
+
+    def symbol_info_tick(self, symbol: str):
+        """Obtém o último tick do símbolo."""
+        return mt5.symbol_info_tick(symbol)
+
     def positions(self, symbol: Optional[str] = None) -> List[PositionView]:
         poss = mt5.positions_get(symbol=symbol)
         out = []

--- a/fxbot/exec/execution.py
+++ b/fxbot/exec/execution.py
@@ -164,8 +164,7 @@ class Executor:
                 return None
 
             pos = open_mine[0]
-            from MetaTrader5 import symbol_info_tick
-            t = symbol_info_tick(symbol)
+            t = self.broker.symbol_info_tick(symbol)
             pos_is_buy = (getattr(pos, "side", None) == Side.BUY) or (getattr(pos, "side", None) and getattr(pos, "side").name == "BUY")
             side_match = (pos_is_buy and sig.side == Side.BUY) or ((not pos_is_buy) and sig.side == Side.SELL)
             price_now = t.bid if pos_is_buy else t.ask

--- a/fxbot/risk/risk_manager.py
+++ b/fxbot/risk/risk_manager.py
@@ -30,8 +30,8 @@ class RiskManager:
         return round(entry, digits), round(sl, digits), round(tp, digits)
 
     def lot_by_risk(self, symbol, stop_distance_price: float, risk_pct: float):
-        import MetaTrader5 as mt5
-        info = mt5.symbol_info(symbol)
+        """Calcula o lote com base no risco desejado."""
+        info = self.broker.symbol_info(symbol)
         if not info or stop_distance_price <= 0:
             return 0.0
         tick_value = info.trade_tick_value or 0.0
@@ -49,8 +49,8 @@ class RiskManager:
 
     def build_order(self, symbol: str, side: Side, atr_value: float, confidence: float, magic: int,
                     risk_pct: Optional[float] = None) -> OrderRequest:
-        from MetaTrader5 import symbol_info_tick
-        t = symbol_info_tick(symbol)
+        """Monta a requisição de ordem usando dados do broker."""
+        t = self.broker.symbol_info_tick(symbol)
         entry = t.ask if side == Side.BUY else t.bid
         sl = entry - self.cfg.atr_mult_sl * \
             atr_value if side == Side.BUY else entry + self.cfg.atr_mult_sl*atr_value


### PR DESCRIPTION
## Resumo
- adiciona symbol_info e symbol_info_tick na interface Broker
- usa Broker no RiskManager e no Executor
- implementa métodos correspondentes no MT5Broker

## Testes
- `pip install -r requirements.txt` *(falhou: MetaTrader5 indisponível)*
- `pip install pandas`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e0018f9c4832e88cb9f0e1da17320