### PR TITLE
Refatora get_logger para usar logger filho do principal

### DIFF
--- a/fxbot/core/logging.py
+++ b/fxbot/core/logging.py
@@ -1,0 +1,21 @@
+import logging
+from pathlib import Path
+
+
+def _configure_root() -> logging.Logger:
+    """Configure o logger principal 'fxbot' apenas uma vez."""
+    root = logging.getLogger("fxbot")
+    if not root.handlers:
+        log_dir = Path(__file__).resolve().parents[1] / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_dir / "fxbot.log", encoding="utf-8")
+        formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+        root.setLevel(logging.INFO)
+    return root
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Retorna um logger filho do logger principal do projeto."""
+    return _configure_root().getChild(name)


### PR DESCRIPTION
## Sumário
- configura logger principal `fxbot`
- retorna `get_logger` como filho do logger principal

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2ab335d4832e8708d3a7d5bc8e5b